### PR TITLE
fix: link variant button now is visible in dark mode

### DIFF
--- a/streamlit_shadcn_ui/components/packages/frontend/src/components/ui/button.tsx
+++ b/streamlit_shadcn_ui/components/packages/frontend/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
                 secondary:
                     "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
                 ghost: "hover:bg-accent hover:text-accent-foreground",
-                link: "text-primary underline-offset-4 hover:underline",
+                link: "underline-offset-4 hover:underline",
             },
             size: {
                 default: "h-9 px-4 py-2",


### PR DESCRIPTION
This commit ensures that the text color for link variant button matches that of the outline and ghost variants, with all having a text color value of `inherit`.

Before:
![屏幕截图 2024-05-03 200623](https://github.com/ObservedObserver/streamlit-shadcn-ui/assets/67158072/dbed3db1-a2e3-4013-88fb-c6112a3fc668)

After:
![屏幕截图 2024-05-03 205412](https://github.com/ObservedObserver/streamlit-shadcn-ui/assets/67158072/f26f8450-ec4e-4ea8-aa9d-cf987866c82a)
