### PR TITLE
docs: include link to PyCafe for a live example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ ui.alert_dialog(show=trigger_btn, title="Alert Dialog", description="This is an 
 
 ```
 
+[<img src="https://py.cafe/logos/pycafe_logo.png" alt="PyCafe logo" width="24" height="24"> Run and edit this example in Py.Cafe](https://py.cafe/maartenbreddels/streamlit-shadcn-ui-example)
+
 ## Components
 
 Check docs and compoenent examples in [![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://shadcn.streamlit.app/)


### PR DESCRIPTION
Hi 👋 ,

awesome streamlit library!
A while ago, we helped the streamlit-folium library to get a link to PyCafe in their docs so that people can try out the library live in their browser: https://github.com/randyzwitch/streamlit-folium/pull/210

We see people really using, and we are wondering if you'd like to have a link like this as well?

If you are worried about maintaining it, or having it under my name: You can login with your GitHub account, fork my project and make edits to it. Randy just merged it as is, and plans to do that only when needed.

Questions welcome, I hope you like it.

Regards,

Maarten