### PR TITLE
Add outside event hook for select

### DIFF
--- a/streamlit_shadcn_ui/components/packages/frontend/src/hooks/useOutsideEvent.ts
+++ b/streamlit_shadcn_ui/components/packages/frontend/src/hooks/useOutsideEvent.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+
+export function useOutsideEvent(
+    eventName: keyof DocumentEventMap,
+    handler: (event: Event) => void,
+    enabled = true
+) {
+    useEffect(() => {
+        if (!enabled) return;
+        const parentDoc = (() => {
+            try {
+                return window.parent.document;
+            } catch (e) {
+                return null;
+            }
+        })();
+
+        document.addEventListener(eventName, handler);
+        if (parentDoc && parentDoc !== document) {
+            parentDoc.addEventListener(eventName, handler);
+        }
+
+        return () => {
+            document.removeEventListener(eventName, handler);
+            if (parentDoc && parentDoc !== document) {
+                parentDoc.removeEventListener(eventName, handler);
+            }
+        };
+    }, [eventName, handler, enabled]);
+}


### PR DESCRIPTION
## Summary
- add a new React hook `useOutsideEvent` that registers listeners on `document` and `window.parent.document`
- use the hook in `StSelectOptions` to close the dropdown when clicking outside

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing dependencies)*
- `pytest -q` *(fails: command not found)*