### PR TITLE
Add parent portal hook and send close event from overlay

### DIFF
--- a/streamlit_shadcn_ui/components/packages/frontend/src/components/ui/dialog.tsx
+++ b/streamlit_shadcn_ui/components/packages/frontend/src/components/ui/dialog.tsx
@@ -5,28 +5,46 @@ import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { useParentPortal } from "@/hooks/useParentPortal"
+import { Streamlit } from "streamlit-component-lib"
 
 const Dialog = DialogPrimitive.Root
 
 const DialogTrigger = DialogPrimitive.Trigger
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogPortal = ({ children, ...props }: DialogPrimitive.DialogPortalProps) => {
+  const container = useParentPortal()
+  if (!container) return null
+  return (
+    <DialogPrimitive.Portal container={container} {...props}>
+      {children}
+    </DialogPrimitive.Portal>
+  )
+}
+DialogPortal.displayName = DialogPrimitive.Portal.displayName
 
 const DialogClose = DialogPrimitive.Close
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      "fixed inset-0 z-50 bg-background/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, onClick, ...props }, ref) => {
+  const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    onClick?.(e)
+    Streamlit.setComponentValue({ confirm: false, open: false })
+  }
+  return (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      onClick={handleClick}
+      className={cn(
+        "fixed inset-0 z-50 bg-background/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+})
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<

--- a/streamlit_shadcn_ui/components/packages/frontend/src/hooks/useParentPortal.ts
+++ b/streamlit_shadcn_ui/components/packages/frontend/src/hooks/useParentPortal.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export function useParentPortal(): HTMLElement | null {
+    const [container, setContainer] = useState<HTMLElement | null>(null);
+
+    useEffect(() => {
+        const parentDoc = window.parent?.document;
+        if (!parentDoc) return;
+        const el = parentDoc.createElement("div");
+        parentDoc.body.appendChild(el);
+        setContainer(el);
+        return () => {
+            parentDoc.body.removeChild(el);
+        };
+    }, []);
+
+    return container;
+}
+


### PR DESCRIPTION
## Summary
- create `useParentPortal` hook that mounts a container in `window.parent.document`
- use that container for dialog portals
- emit `Streamlit.setComponentValue({confirm:false, open:false})` when the dialog overlay is clicked

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*