### PR TITLE
fix: close select dropdown when clicking outside

### DIFF
--- a/streamlit_shadcn_ui/py_components/select.py
+++ b/streamlit_shadcn_ui/py_components/select.py
@@ -13,7 +13,7 @@ def select_trigger(value=None, open_status=False, key=None):
     props = {"value": value, "open": open_status}
     return _component_func(comp=name, props=props, key=key, default={"x": 0, "y": 0, "open": False})
 
-def select_options(options: List[str], x, y, open_status=False, key=None, default_value=None, on_change=None, args=None, kwargs=None):
+def select_options(options: List[str], x, y, open_status=False, key=None, value=None, default_value=None, on_change=None, args=None, kwargs=None):
     name = "select_options"
     _component_func = declare_component(name)
     register_callback(key=key, callback=on_change, args=args, kwargs=kwargs)
@@ -28,7 +28,7 @@ def select_options(options: List[str], x, y, open_status=False, key=None, defaul
         """)
     result = default_value
     with container:
-        props = {"options": options}
+        props = {"options": options, "value": value, "open": open_status}
         result = _component_func(comp=name, props=props, key=key, default={"value": default_value, "open": False})
         return result
 
@@ -53,7 +53,7 @@ def select(label=None, options=None, key="ui_select"):
 
         trigger_state = select_trigger(value=choice, open_status=open_status, key=trigger_component_key)
 
-        options_state = select_options(options=option_list, x=trigger_state['x'], y=trigger_state['y'], open_status=open_status, default_value=option_list[0], key=options_component_key, on_change=option_choosen_handler, kwargs={"from_key": options_component_key, "to_key": trigger_component_key})
+        options_state = select_options(options=option_list, x=trigger_state['x'], y=trigger_state['y'], open_status=open_status, value=choice, default_value=option_list[0], key=options_component_key, on_change=option_choosen_handler, kwargs={"from_key": options_component_key, "to_key": trigger_component_key})
 
         choice = options_state['value']
         return choice


### PR DESCRIPTION
## Summary
- close the select options panel when interactions occur outside the component
- keep the trigger and options components in sync by passing the current value and open status

## Testing
- yarn --cwd streamlit_shadcn_ui/components/packages/frontend build *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68eff67f67e88322825fdb6ea9776173