### PR TITLE
Enhance breadcrumb component separator support

### DIFF
--- a/docs/components/bread_crumb.md
+++ b/docs/components/bread_crumb.md
@@ -11,8 +11,12 @@ ui.breadcrumb(
         {"text": "Breadcrumb", "isCurrentPage": True},
     ],
     class_name="flex gap-2 text-sm",
+    separator="/",
     key="breadcrumb1"
 )
+
+The optional `separator` argument lets you customise the character that appears between breadcrumb items. If it is not
+provided the default chevron icon from the shadcn/ui breadcrumb component is used.
 
 st.write(ui.breadcrumb)
 ```

--- a/pages/BreadCrumb.py
+++ b/pages/BreadCrumb.py
@@ -14,6 +14,7 @@ ui.breadcrumb(
         {"text": "Breadcrumb", "isCurrentPage": True},
     ],
     class_name="flex gap-2 text-sm",
+    separator="/",
     key="breadcrumb1"
 )
 

--- a/streamlit_shadcn_ui/py_components/breadcrumb.py
+++ b/streamlit_shadcn_ui/py_components/breadcrumb.py
@@ -1,13 +1,16 @@
 from .utils import declare_component
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
 _component_func = declare_component("breadcrumb")
 
+
 def breadcrumb(
-    breadcrumb_items: List[Dict[str, Optional[str]]], 
-    class_name: Optional[str] = None, 
-    key=None
+    breadcrumb_items: List[Dict[str, Optional[str]]],
+    class_name: Optional[str] = None,
+    separator: Optional[str] = None,
+    key: Optional[str] = None,
 ):
+    """Render a breadcrumb navigation component."""
 
     items = [
         {
@@ -17,9 +20,17 @@ def breadcrumb(
         }
         for item in breadcrumb_items
     ]
-    props = {
-        "items": items,
-        "className": class_name,
-    }
-    component_value =  _component_func(comp="breadcrumb", props=props, key=key, default=None)
+
+    props = {"items": items}
+
+    if class_name is not None:
+        props["className"] = class_name
+
+    if separator is not None:
+        props["separator"] = separator
+
+    component_value = _component_func(
+        comp="breadcrumb", props=props, key=key, default=None
+    )
     return component_value
+


### PR DESCRIPTION
## Summary
- add optional separator support to the breadcrumb Streamlit component API
- document the new option in the demo page and component guide

## Testing
- python -m compileall streamlit_shadcn_ui/py_components/breadcrumb.py

------
https://chatgpt.com/codex/tasks/task_e_68eff601b9208322871522e8393fc711