### PR TITLE
Fix dark mode synchronization for Streamlit components

### DIFF
--- a/streamlit_shadcn_ui/components/packages/frontend/src/App.tsx
+++ b/streamlit_shadcn_ui/components/packages/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import "./App.css";
 import {
     ComponentProps,
@@ -98,6 +98,23 @@ function App(props: ComponentProps<{comp: string; props: any; [key: string]: any
     // TODO: different safe-height for different components
     // 10px is the minimum safe height for slider, while most of the other components do not need it.
     useAutoHeight(container, safeHeight);
+
+    useEffect(() => {
+        const root = document.documentElement;
+        const body = document.body;
+        const isDark = theme?.base === "dark";
+        root.classList.toggle("dark", isDark);
+        root.style.colorScheme = isDark ? "dark" : "light";
+        body.style.colorScheme = isDark ? "dark" : "light";
+
+        if (theme?.base) {
+            body.dataset.theme = theme.base;
+            root.dataset.theme = theme.base;
+        } else {
+            delete body.dataset.theme;
+            delete root.dataset.theme;
+        }
+    }, [theme?.base]);
 
     return crouter.render(args.comp, container, args.props);
 }


### PR DESCRIPTION
## Summary
- synchronize the frontend with the Streamlit theme to toggle the dark mode class
- update the document color scheme and theme data attributes for consistent styling

## Testing
- Not run (build environment requires installing workspace packages)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691187d2b8e88322a10251c3002588d0)